### PR TITLE
Close Dask client and cluster after execution

### DIFF
--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -54,6 +54,13 @@ class DaskResource(object):
     @property
     def client(self):
         return self._client
+        
+    def close(self):
+        self.client.close()
+        if self.cluster:
+            self.cluster.close()
+        
+        self._client, self._cluster = None, None
 
 
 @resource(
@@ -130,3 +137,5 @@ def dask_resource(context):
     resource = DaskResource(context)
     
     yield resource
+
+    resource.close()

--- a/python_modules/libraries/dagster-dask/dagster_dask/resources.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask/resources.py
@@ -127,4 +127,6 @@ class DaskResource(object):
     ),
 )
 def dask_resource(context):
-    return DaskResource(context)
+    resource = DaskResource(context)
+    
+    yield resource


### PR DESCRIPTION
Close the Dask client and cluster in Dask resources after execution resolves.

Closes #2940.